### PR TITLE
Fetch whole layer in background

### DIFF
--- a/script/integration/containerd/entrypoint.sh
+++ b/script/integration/containerd/entrypoint.sh
@@ -64,21 +64,6 @@ function reboot_containerd {
     retry ctr version
 }
 
-SSNAPSHOTD_ROOT=/var/lib/containerd-stargz-grpc/
-function cleanup {
-    ORG_EXIT_CODE="${1}"
-    echo "Cleaning up /var/lib/containerd-stargz-grpc..."
-    if [ -d "${SSNAPSHOTD_ROOT}snapshotter/snapshots/" ] ; then 
-        find "${SSNAPSHOTD_ROOT}snapshotter/snapshots/" \
-             -maxdepth 1 -mindepth 1 -type d -exec umount "{}/fs" \;
-    fi
-    rm -rf "${SSNAPSHOTD_ROOT}"*
-    echo "Exit with code: ${ORG_EXIT_CODE}"
-    exit "${ORG_EXIT_CODE}"
-}
-
-trap 'cleanup $?' EXIT SIGHUP SIGINT SIGQUIT SIGTERM
-
 echo "Logging into the registry..."
 cp /auth/certs/domain.crt /usr/local/share/ca-certificates
 update-ca-certificates

--- a/stargz/filereaderat_test.go
+++ b/stargz/filereaderat_test.go
@@ -238,13 +238,13 @@ func TestPrefetch(t *testing.T) {
 				r:     r,
 				cache: &testCache{membuf: map[string]string{}, t: t},
 			}
-			done, err := gr.prefetch(sr)
+			cache, err := gr.prefetch(sr)
 			if err != nil {
 				t.Errorf("failed to prefetch: %v", err)
 				return
 			}
-			if done(); tt.wantNum != len(gr.cache.(*testCache).membuf) {
-				t.Errorf("number of chunks in the cache %d; want %d", len(gr.cache.(*testCache).membuf), tt.wantNum)
+			if err := cache(); err != nil || tt.wantNum != len(gr.cache.(*testCache).membuf) {
+				t.Errorf("number of chunks in the cache %d; want %d: %v", len(gr.cache.(*testCache).membuf), tt.wantNum, err)
 				return
 			}
 
@@ -349,23 +349,16 @@ func TestFailStargzReader(t *testing.T) {
 
 	// tests for prefetch
 	br.success = true
-	done, err := gr.prefetch(io.NewSectionReader(br, 0, stargzFile.Size()))
-	if done(); err != nil {
+	_, err = gr.prefetch(io.NewSectionReader(br, 0, stargzFile.Size()))
+	if err != nil {
 		t.Errorf("failed to prefetch but wanted to succeed: %v", err)
 		return
 	}
 
 	br.success = false
-	done, err = gr.prefetch(io.NewSectionReader(br, 0, stargzFile.Size()))
-	if done(); err == nil {
+	_, err = gr.prefetch(io.NewSectionReader(br, 0, stargzFile.Size()))
+	if err == nil {
 		t.Errorf("succeeded to prefetch but wanted to fail")
-		return
-	}
-
-	dummyData := []byte("dummy") // wants to be succeeded even for dummy data
-	done, err = gr.prefetch(io.NewSectionReader(bytes.NewReader(dummyData), 0, int64(len(dummyData))))
-	if done(); err != nil {
-		t.Errorf("failed to prefetch for dummy but wanted to succeed: %v", err)
 		return
 	}
 }

--- a/stargz/fs.go
+++ b/stargz/fs.go
@@ -31,6 +31,7 @@
 package stargz
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -60,6 +61,7 @@ import (
 	"github.com/ktock/stargz-snapshotter/cache"
 	snbase "github.com/ktock/stargz-snapshotter/snapshot"
 	"github.com/ktock/stargz-snapshotter/stargz/handler"
+	"github.com/ktock/stargz-snapshotter/task"
 	"golang.org/x/sys/unix"
 )
 
@@ -102,12 +104,13 @@ func getCache(ctype, dir string, maxEntry int) (cache.BlobCache, error) {
 func NewFilesystem(root string, config *Config) (snbase.FileSystem, error) {
 	var err error
 	fs := &filesystem{
-		httpCacheChunkSize: config.HTTPCacheChunkSize,
-		noprefetch:         config.NoPrefetch,
-		insecure:           config.Insecure,
-		pullTransports:     make(map[string]http.RoundTripper),
-		conn:               make(map[string]*connection),
-		debug:              config.Debug,
+		httpCacheChunkSize:    config.HTTPCacheChunkSize,
+		noprefetch:            config.NoPrefetch,
+		insecure:              config.Insecure,
+		pullTransports:        make(map[string]http.RoundTripper),
+		conn:                  make(map[string]*connection),
+		debug:                 config.Debug,
+		backgroundTaskManager: task.NewBackgroundTaskManager(2, 5*time.Second),
 	}
 	if fs.httpCacheChunkSize == 0 {
 		fs.httpCacheChunkSize = defaultHTTPCacheChunkSize
@@ -138,17 +141,18 @@ func NewFilesystem(root string, config *Config) (snbase.FileSystem, error) {
 }
 
 type filesystem struct {
-	httpCacheChunkSize int64
-	httpCache          cache.BlobCache
-	fsCache            cache.BlobCache
-	layerValidInterval time.Duration
-	noprefetch         bool
-	insecure           []string
-	pullTransports     map[string]http.RoundTripper
-	pullTransportsMu   sync.Mutex
-	conn               map[string]*connection
-	connMu             sync.Mutex
-	debug              bool
+	httpCacheChunkSize    int64
+	httpCache             cache.BlobCache
+	fsCache               cache.BlobCache
+	layerValidInterval    time.Duration
+	noprefetch            bool
+	insecure              []string
+	pullTransports        map[string]http.RoundTripper
+	pullTransportsMu      sync.Mutex
+	conn                  map[string]*connection
+	connMu                sync.Mutex
+	debug                 bool
+	backgroundTaskManager *task.BackgroundTaskManager
 }
 
 type connection struct {
@@ -158,6 +162,12 @@ type connection struct {
 }
 
 func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[string]string) error {
+	// This Mount functionality is a prioritized task and all background
+	// tasks will be stopped during the execution so this can avoid being
+	// disturbed for NW traffic by background tasks.
+	fs.backgroundTaskManager.DoPrioritizedTask()
+	defer fs.backgroundTaskManager.DonePrioritizedTask()
+
 	ref, ok := labels[handler.TargetRefLabel]
 	if !ok {
 		log.G(ctx).Debug("stargz: reference hasn't been passed")
@@ -192,11 +202,12 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 
 	// Construct filesystem from the remote stargz layer.
 	ur := &urlReaderAt{
-		url:       url,
-		t:         tr,
-		size:      size,
-		chunkSize: fs.httpCacheChunkSize,
-		cache:     fs.httpCache,
+		url:                   url,
+		t:                     tr,
+		size:                  size,
+		chunkSize:             fs.httpCacheChunkSize,
+		cache:                 fs.httpCache,
+		backgroundTaskManager: fs.backgroundTaskManager,
 	}
 	sr := io.NewSectionReader(ur, 0, size)
 	r, err := stargz.Open(sr)
@@ -215,11 +226,33 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 	}
 	if !fs.noprefetch {
 		// TODO: make sync/async switchable
-		if _, err := gr.prefetch(sr); err != nil {
-			log.G(ctx).WithError(err).WithField("url", url).Debug("stargz: failed to prefetch layer")
+		cache, err := gr.prefetch(sr)
+		if err != nil {
+			log.G(ctx).WithError(err).WithField("digest", digest).WithField("url", url).Debug("stargz: failed to prefetch layer")
 			return err
 		}
+		go func() {
+			if err := cache(); err != nil {
+				log.G(ctx).WithError(err).WithField("digest", digest).WithField("url", url).Warning("error occurred during caching")
+				return
+			}
+			log.G(ctx).WithField("digest", digest).WithField("url", url).Debug("prefetch completed")
+		}()
 	}
+
+	// Fetch whole layer aggressively in background. We use background
+	// reader for this so prioritized tasks(Mount, Check, etc...) can
+	// interrupt the reading. This can avoid disturbing prioritized tasks
+	// about NW traffic. We read layer with a buffer to reduce num of
+	// requests to the registry.
+	go func() {
+		pr := bufio.NewReaderSize(io.NewSectionReader(ur.backgroundReaderAt(), 0, size), 2<<28)
+		if err := gr.cacheTarGz(pr); err != nil && err != io.EOF {
+			log.G(ctx).WithError(err).WithField("digest", digest).WithField("url", url).Warning("error during fetching in background")
+			return
+		}
+		log.G(ctx).WithField("digest", digest).WithField("url", url).Debug("fetched all layer data in background")
+	}()
 
 	// Mounting stargz
 	// TODO: bind mount the state directory as a read-only fs on snapshotter's side
@@ -248,6 +281,11 @@ func (fs *filesystem) Mount(ctx context.Context, mountpoint string, labels map[s
 }
 
 func (fs *filesystem) Check(ctx context.Context, mountpoint string) (err error) {
+	// This Check functionality is a prioritized task and all background
+	// tasks will be stopped during the execution so this can avoid being
+	// disturbed for NW traffic by background tasks.
+	fs.backgroundTaskManager.DoPrioritizedTask()
+	defer fs.backgroundTaskManager.DonePrioritizedTask()
 	fs.connMu.Lock()
 	defer fs.connMu.Unlock()
 	var (

--- a/stargz/fs_test.go
+++ b/stargz/fs_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/google/crfs/stargz"
 	"github.com/hanwen/go-fuse/fuse"
 	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/ktock/stargz-snapshotter/task"
 	"golang.org/x/sys/unix"
 )
 
@@ -48,8 +49,9 @@ func TestCheckInterval(t *testing.T) {
 			tr:  tr,
 		}
 		fs = &filesystem{
-			conn:               map[string]*connection{"test": c},
-			layerValidInterval: largeInterval,
+			conn:                  map[string]*connection{"test": c},
+			layerValidInterval:    largeInterval,
+			backgroundTaskManager: task.NewBackgroundTaskManager(1, time.Second),
 		}
 	)
 
@@ -121,7 +123,8 @@ func TestCheck(t *testing.T) {
 				tr:  tr,
 			},
 		},
-		layerValidInterval: 0,
+		layerValidInterval:    0,
+		backgroundTaskManager: task.NewBackgroundTaskManager(1, time.Second),
 	}
 	tr.success = true
 	if err := fs.Check(context.TODO(), "test"); err != nil {

--- a/stargz/urlreaderat_test.go
+++ b/stargz/urlreaderat_test.go
@@ -30,6 +30,9 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/ktock/stargz-snapshotter/task"
 )
 
 const (
@@ -177,11 +180,12 @@ func TestFailReadAt(t *testing.T) {
 
 func makeURLReaderAt(t *testing.T, contents []byte, chunkSize int64, fn RoundTripFunc) *urlReaderAt {
 	return &urlReaderAt{
-		url:       testURL,
-		t:         fn,
-		size:      int64(len(contents)),
-		chunkSize: chunkSize,
-		cache:     &testCache{membuf: map[string]string{}, t: t},
+		url:                   testURL,
+		t:                     fn,
+		size:                  int64(len(contents)),
+		chunkSize:             chunkSize,
+		cache:                 &testCache{membuf: map[string]string{}, t: t},
+		backgroundTaskManager: task.NewBackgroundTaskManager(1, time.Millisecond),
 	}
 }
 

--- a/task/task.go
+++ b/task/task.go
@@ -1,0 +1,140 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package task
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// NewBackgroundTaskManager provides a task manager. You can specify the
+// concurrency of background tasks. When running a background task, this will be
+// forced to wait until no prioritized task is running for some period. You can
+// specify the period through the argument of this function, too.
+func NewBackgroundTaskManager(concurrency int64, period time.Duration) *BackgroundTaskManager {
+	return &BackgroundTaskManager{
+		backgroundSem:                semaphore.NewWeighted(concurrency),
+		prioritizedTaskSilencePeriod: period,
+		prioritizedTaskCond:          sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+// BackgroundTaskManager is a task manager which manages prioritized tasks and
+// background tasks execution. Background tasks are less important than
+// prioritized tasks. You can let these background tasks not to use compute
+// resources (CPU, NW, etc...) during more important tasks(=prioritized tasks)
+// running.
+//
+// When you run a prioritised task and don't want background tasks to use
+// resources you can tell it this manager by calling DoPrioritizedTask method.
+// DonePrioritizedTask method must be called at the end of the prioritised task
+// execution.
+//
+// For running a background task, you can use InvokeBackgroundTask method. The
+// background task must be able to be cancelled via context.Context argument.
+// The task is forced to wait until no prioritized task is running for some
+// period. You can specify the period when making this manager instance. The
+// limited number of background tasks run simultaneously and you can specify the
+// concurrency when making this manager instance too. If a prioritized task
+// starts during the execution of background tasks, all background tasks running
+// will be cancelled via context. These cancelled tasks will be executed again
+// later, same as other background tasks (when no prioritized task is running
+// for some period).
+type BackgroundTaskManager struct {
+	prioritizedTasks             int64
+	backgroundSem                *semaphore.Weighted
+	prioritizedTaskSilencePeriod time.Duration
+	prioritizedTaskCond          *sync.Cond
+}
+
+// DoPrioritizedTask tells the manager that we are running a prioritized task
+// and don't want background tasks to disturb resources(CPU, NW, etc...)
+func (ts *BackgroundTaskManager) DoPrioritizedTask() {
+	atomic.AddInt64(&ts.prioritizedTasks, 1)
+	ts.prioritizedTaskCond.Broadcast()
+}
+
+// DonePrioritizedTask tells the manager that we've done a prioritized task
+// and don't want background tasks to disturb resources(CPU, NW, etc...)
+func (ts *BackgroundTaskManager) DonePrioritizedTask() {
+	atomic.AddInt64(&ts.prioritizedTasks, -1)
+}
+
+// InvokeBackgroundTask invokes a background task. The task is started only when
+// no prioritized tasks are running. Prioritized task's execution stops the
+// execution of all background tasks. Background task must be able to be
+// cancelled via context.Context argument and be able to be restarted again.
+func (ts *BackgroundTaskManager) InvokeBackgroundTask(do func(context.Context), timeout time.Duration) {
+	waitUntilPrioritizedTaskRunning := func() <-chan int64 {
+		ch := make(chan int64)
+		go func() {
+			if ts.prioritizedTasks <= 0 {
+				// waits until prioritized tasks are started
+				ts.prioritizedTaskCond.L.Lock()
+				ts.prioritizedTaskCond.Wait()
+				ts.prioritizedTaskCond.L.Unlock()
+			}
+			ch <- ts.prioritizedTasks
+		}()
+		return ch
+	}
+
+try:
+	// if nobody add prioritized tasks in specified period, this is a
+	// chance for us to do some background tasks
+	select {
+	case <-time.After(ts.prioritizedTaskSilencePeriod):
+	case <-waitUntilPrioritizedTaskRunning():
+		time.Sleep(time.Second)
+		goto try
+	}
+
+	complete := func() bool {
+		// limited number of background tasks can run at once.
+		// if prioritized tasks are running, cancel this task.
+		ts.backgroundSem.Acquire(context.Background(), 1)
+		defer ts.backgroundSem.Release(1)
+		if ts.prioritizedTasks > 0 {
+			return false
+		}
+
+		// read required range. if some prioritized tasks added during
+		// reading, cancel the work and wait again.
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		done := make(chan struct{})
+		go func() {
+			do(ctx)
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-waitUntilPrioritizedTaskRunning():
+			cancel()
+			return false
+		}
+		return true
+	}()
+
+	if !complete {
+		goto try
+	}
+}

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -1,0 +1,228 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package task
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestBackgroundTasks tests background task manager.
+func TestBackgroundTasks(t *testing.T) {
+	doGo := func(f func()) {
+		invoked := make(chan struct{})
+		go func() {
+			invoked <- struct{}{}
+			f()
+		}()
+		<-invoked
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	wait := func(t *testing.T, name string, c *bool) {
+		ch := make(chan struct{})
+		go func() {
+			for !*c {
+				time.Sleep(10 * time.Millisecond)
+			}
+			ch <- struct{}{}
+		}()
+		select {
+		case <-ch:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timeout for %s", name)
+		}
+	}
+
+	tests := []struct {
+		name          string
+		concurrency   int64
+		checkInterval time.Duration
+		context       func(t *testing.T, pm *BackgroundTaskManager, task1, task2, task3, task4 *sampleTask)
+		assert        func(task1, task2, task3, task4 *sampleTask) bool
+	}{
+		{
+			name:          "privilege_running",
+			concurrency:   1,
+			checkInterval: 100 * time.Millisecond,
+			context: func(t *testing.T, pm *BackgroundTaskManager, task1, task2, task3, task4 *sampleTask) {
+				pm.DoPrioritizedTask()
+				doGo(func() { pm.InvokeBackgroundTask(task1.do, 24*time.Hour) })
+				time.Sleep(300 * time.Millisecond) // wait for long time...
+			},
+			assert: func(task1, task2, task3, task4 *sampleTask) bool {
+				return (task1.assert(false, false, false))
+			},
+		},
+		{
+			name:          "concurrency",
+			concurrency:   2,
+			checkInterval: time.Duration(0), // We don't care prioritized tasks now
+			context: func(t *testing.T, pm *BackgroundTaskManager, task1, task2, task3, task4 *sampleTask) {
+				doGo(func() { pm.InvokeBackgroundTask(task1.do, 24*time.Hour) })
+				wait(t, "task1 started", &task1.started)
+				doGo(func() { pm.InvokeBackgroundTask(task2.do, 24*time.Hour) })
+				wait(t, "task2 started", &task2.started)
+				doGo(func() { pm.InvokeBackgroundTask(task3.do, 24*time.Hour) })
+				doGo(func() { pm.InvokeBackgroundTask(task4.do, 24*time.Hour) })
+				time.Sleep(300 * time.Millisecond) // wait for long time...
+			},
+			assert: func(task1, task2, task3, task4 *sampleTask) bool {
+				return (task1.assert(true, false, false) &&
+					task2.assert(true, false, false) &&
+					task3.assert(false, false, false) &&
+					task4.assert(false, false, false))
+			},
+		},
+		{
+			name:          "cancel",
+			concurrency:   2,
+			checkInterval: 100 * time.Millisecond,
+			context: func(t *testing.T, pm *BackgroundTaskManager, task1, task2, task3, task4 *sampleTask) {
+				doGo(func() { pm.InvokeBackgroundTask(task1.do, 24*time.Hour) })
+				wait(t, "task1 started", &task1.started)
+				doGo(func() { pm.InvokeBackgroundTask(task2.do, 24*time.Hour) })
+				wait(t, "task2 started", &task2.started)
+				pm.DoPrioritizedTask()
+				wait(t, "task1 canceled", &task1.canceled)
+				wait(t, "task2 canceled", &task2.canceled)
+			},
+			assert: func(task1, task2, task3, task4 *sampleTask) bool {
+				return (task1.assert(true, false, true) &&
+					task2.assert(true, false, true))
+			},
+		},
+		{
+			name:          "resume",
+			concurrency:   2,
+			checkInterval: 100 * time.Millisecond,
+			context: func(t *testing.T, pm *BackgroundTaskManager, task1, task2, task3, task4 *sampleTask) {
+				doGo(func() { pm.InvokeBackgroundTask(task1.do, 24*time.Hour) })
+				wait(t, "task1 started", &task1.started)
+				doGo(func() { pm.InvokeBackgroundTask(task2.do, 24*time.Hour) })
+				wait(t, "task2 started", &task2.started)
+				pm.DoPrioritizedTask()
+				wait(t, "task1 canceled", &task1.canceled)
+				wait(t, "task2 canceled", &task2.canceled)
+				task1.reset()
+				task2.reset()
+				pm.DonePrioritizedTask()
+				wait(t, "task1 resumed", &task1.started)
+				wait(t, "task2 resumed", &task2.started)
+			},
+			assert: func(task1, task2, task3, task4 *sampleTask) bool {
+				return (task1.assert(true, false, false) &&
+					task2.assert(true, false, false))
+			},
+		},
+		{
+			name:          "finish_partial",
+			concurrency:   1,
+			checkInterval: time.Duration(0), // We don't care prioritized tasks now
+			context: func(t *testing.T, pm *BackgroundTaskManager, task1, task2, task3, task4 *sampleTask) {
+				doGo(func() { pm.InvokeBackgroundTask(task1.do, 24*time.Hour) })
+				wait(t, "task1 started", &task1.started)
+				doGo(func() { pm.InvokeBackgroundTask(task2.do, 24*time.Hour) })
+				task1.finish()
+				wait(t, "task1 done", &task1.done)
+				wait(t, "task2 started", &task2.started)
+			},
+			assert: func(task1, task2, task3, task4 *sampleTask) bool {
+				return (task1.assert(true, true, false) &&
+					task2.assert(true, false, false))
+			},
+		},
+		{
+			name:          "finish_all",
+			concurrency:   1,
+			checkInterval: time.Duration(0), // We don't care prioritized tasks now
+			context: func(t *testing.T, pm *BackgroundTaskManager, task1, task2, task3, task4 *sampleTask) {
+				doGo(func() { pm.InvokeBackgroundTask(task1.do, 24*time.Hour) })
+				wait(t, "task1 started", &task1.started)
+				doGo(func() { pm.InvokeBackgroundTask(task2.do, 24*time.Hour) })
+				task1.finish()
+				wait(t, "task1 done", &task1.done)
+				wait(t, "task2 started", &task2.started)
+				task2.finish()
+				wait(t, "task2 done", &task2.done)
+			},
+			assert: func(task1, task2, task3, task4 *sampleTask) bool {
+				return (task1.assert(true, true, false) &&
+					task2.assert(true, true, false))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				pm    = NewBackgroundTaskManager(tt.concurrency, tt.checkInterval)
+				task1 = newSampleTask()
+				task2 = newSampleTask()
+				task3 = newSampleTask()
+				task4 = newSampleTask()
+			)
+			tt.context(t, pm, task1, task2, task3, task4)
+			if !tt.assert(task1, task2, task3, task4) {
+				t.Errorf("assertion failed: status=(task1:%s,task2:%s,task3:%s,task4:%s)",
+					task1.dumpStatus(), task2.dumpStatus(), task3.dumpStatus(), task4.dumpStatus())
+			}
+		})
+	}
+}
+
+type sampleTask struct {
+	started  bool
+	done     bool
+	canceled bool
+	finishCh chan struct{}
+}
+
+func newSampleTask() *sampleTask {
+	return &sampleTask{
+		finishCh: make(chan struct{}),
+	}
+}
+
+func (st *sampleTask) do(ctx context.Context) {
+	st.started = true
+	select {
+	case <-st.finishCh:
+		st.done = true
+	case <-ctx.Done():
+		st.canceled = true
+	}
+}
+
+func (st *sampleTask) finish() {
+	st.finishCh <- struct{}{}
+}
+
+func (st *sampleTask) reset() {
+	st.started, st.done, st.canceled = false, false, false
+	st.finishCh = make(chan struct{})
+}
+
+func (st *sampleTask) dumpStatus() string {
+	return fmt.Sprintf("started=%v,done=%v,canceled=%v", st.started, st.done, st.canceled)
+}
+
+func (st *sampleTask) assert(started, done, canceled bool) bool {
+	return (st.started == started) && (st.done == done) && (st.canceled == canceled)
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -2,7 +2,7 @@
 github.com/containerd/continuity f2a389ac0a02ce21c09edd7344677a601970f41c
 github.com/pkg/errors v0.8.1 # indirect
 github.com/sirupsen/logrus v1.4.1 # indirect
-golang.org/x/sync 42b317875d0fa942474b76e1b46a6060d720ae6e # indirect
+golang.org/x/sync 42b317875d0fa942474b76e1b46a6060d720ae6e
 
 # Depenedencies for stargz filesystem
 github.com/docker/cli a8ff7f821017 # indirect


### PR DESCRIPTION
Background fetching disturbs more important "frontend" tasks(=authentication, redirection, reading files, etc...) so this commit includes a small task manager for less important "preemptive" tasks.

This is related to #30 and possibly give us performance improvement for unoptimized images(mentioned in #29).