### PR TITLE
Govern codes from CRFS project by the license of the project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,14 @@ ctr-remote: FORCE
 check:
 	@echo "$@"
 	@GO111MODULE=$(GO111MODULE_VALUE) golangci-lint run
+	@$(GOPATH)/src/github.com/containerd/project/script/validate/fileheader $(GOPATH)/src/github.com/containerd/project/
 	@git-validation -q -run DCO
 
 install-check-tools:
 	@curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.19.1
 	@go get -u github.com/vbatts/git-validation
+	@go get -u github.com/kunalkushwaha/ltag
+	@git clone https://github.com/containerd/project $(GOPATH)/src/github.com/containerd/project
 
 install:
 	@echo "$@"

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,41 @@
+The source code developed under the Stargz Snapshotter Project is licensed under Apache License 2.0. 
+
+However, the Stargz Snapshotter project contains modified subcomponents from Container Registry Filesystem Project with separate copyright notices and license terms. Your use of the source code for the subcomponent is subject to the terms and conditions as defined by the source project. Files in these subcomponents contain following file header.
+
+```
+Copyright 2019 The Go Authors. All rights reserved.
+Use of this source code is governed by a BSD-style
+license that can be found in the NOTICE.md file.
+```
+
+These source code is governed by a 3-Clause BSD license. The copyright notice, list of conditions and disclaimer are the following.
+
+```
+Copyright (c) 2019 Google LLC. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,6 +1,5 @@
 /*
    Copyright The containerd Authors.
-   Copyright 2019 The Go Authors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,6 +12,12 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
 */
 
 package cache

--- a/cmd/ctr-remote/commands/optimize.go
+++ b/cmd/ctr-remote/commands/optimize.go
@@ -1,6 +1,5 @@
 /*
    Copyright The containerd Authors.
-   Copyright 2019 The Go Authors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,6 +12,12 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
 */
 
 package commands

--- a/cmd/ctr-remote/logger/logger_test.go
+++ b/cmd/ctr-remote/logger/logger_test.go
@@ -1,6 +1,5 @@
 /*
    Copyright The containerd Authors.
-   Copyright 2019 The Go Authors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,6 +12,12 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
 */
 
 package logger

--- a/cmd/ctr-remote/sampler/sampler.go
+++ b/cmd/ctr-remote/sampler/sampler.go
@@ -1,6 +1,5 @@
 /*
    Copyright The containerd Authors.
-   Copyright 2013-2018 Docker, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -195,6 +194,7 @@ func runContainer(ctx context.Context, bundle string) error {
 	return nil
 }
 
+// Copyright 2013-2018 Docker, Inc.
 // Modified version of getUser function to make it work with any rootfs.
 // https://github.com/moby/moby/blob/ad1b781e44fa1e44b9e654e5078929aec56aed66/daemon/oci_linux.go
 func getUser(username string, rootfsPath string) (specs.User, error) {

--- a/cmd/ctr-remote/sorter/sorter_test.go
+++ b/cmd/ctr-remote/sorter/sorter_test.go
@@ -1,6 +1,5 @@
 /*
    Copyright The containerd Authors.
-   Copyright 2019 The Go Authors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,6 +12,12 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
 */
 
 package sorter

--- a/stargz/fs.go
+++ b/stargz/fs.go
@@ -1,6 +1,5 @@
 /*
    Copyright The containerd Authors.
-   Copyright 2019 The Go Authors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,6 +12,12 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
 */
 
 //

--- a/stargz/fs_test.go
+++ b/stargz/fs_test.go
@@ -1,6 +1,5 @@
 /*
    Copyright The containerd Authors.
-   Copyright 2019 The Go Authors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,6 +12,12 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
 */
 
 package stargz

--- a/stargz/reader/reader.go
+++ b/stargz/reader/reader.go
@@ -1,6 +1,5 @@
 /*
    Copyright The containerd Authors.
-   Copyright 2019 The Go Authors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,6 +12,12 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
 */
 
 package reader

--- a/stargz/reader/reader_test.go
+++ b/stargz/reader/reader_test.go
@@ -1,6 +1,5 @@
 /*
    Copyright The containerd Authors.
-   Copyright 2019 The Go Authors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,6 +12,12 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
 */
 
 package reader

--- a/stargz/remote/urlreaderat.go
+++ b/stargz/remote/urlreaderat.go
@@ -1,6 +1,5 @@
 /*
    Copyright The containerd Authors.
-   Copyright 2019 The Go Authors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,6 +12,12 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
 */
 
 package remote

--- a/stargz/remote/urlreaderat_test.go
+++ b/stargz/remote/urlreaderat_test.go
@@ -1,6 +1,5 @@
 /*
    Copyright The containerd Authors.
-   Copyright 2019 The Go Authors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,6 +12,12 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+*/
+
+/*
+   Copyright 2019 The Go Authors. All rights reserved.
+   Use of this source code is governed by a BSD-style
+   license that can be found in the NOTICE.md file.
 */
 
 package remote


### PR DESCRIPTION
Stargz Snapshotter project is partially (mainly for filesystem and image converter) based on CRFS project which is licensed under 3-Clause BSD. We add 3-Clause BSD file header for codes originated from CRFS and add a NOTICE file. Stargz Snapshotter project is still licensed under Apache License 2.0.