### PR TITLE
Enable to benchmark on CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,27 @@
+name: Benchmark
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  hello-bench:
+    runs-on: ubuntu-18.04
+    name: HelloBench
+    env:
+      BENCHMARK_RESULT_DIR: ${{ github.workspace }}/benchmark/
+      BENCHMARK_RESULT_FILENAME: result.md
+      BENCHMARK_USER: ktokunaga
+      BENCHMARK_TARGETS: --all
+    steps:
+    - uses: actions/checkout@v1
+    - name: Prepare output directory
+      run: mkdir "${BENCHMARK_RESULT_DIR}"
+    - name: Run benchmark
+      run: ./script/make.sh benchmark
+    - name: Post the result as a comment
+      run: |
+        jq -n --arg result "$(cat ${BENCHMARK_RESULT_DIR}/${BENCHMARK_RESULT_FILENAME})" '{"body": $result}' | \
+        curl -X POST -d @- \
+             -H "Content-Type: application/json" \
+             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+             ${{ github.event.pull_request.comments_url }}

--- a/Makefile
+++ b/Makefile
@@ -77,3 +77,6 @@ integration:
 
 test-optimize:
 	@./script/make.sh test-optimize
+
+benchmark:
+	@./script/make.sh benchmark

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -39,3 +39,29 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
+
+The Stargz Snapshotter project also contains modified benchmarking code from HelloBench Project with separate copyright notices and license terms. Your use of the source code for the benchmarking code is subject to the terms and conditions as defined by the source project. These source code is governed by a MIT license. The copyright notice, condition and disclaimer are the following. The file in the benchmarking code contains it as the file header.
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Tintri
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/script/benchmark/docker-compose-benchmark.yml.sh
+++ b/script/benchmark/docker-compose-benchmark.yml.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+if [ "${1}" == "" ]; then
+    echo "Repository path must be provided."
+    exit 1
+fi
+
+if [ "${2}" == "" ]; then
+    echo "Container name must be provided."
+    exit 1
+fi
+
+REPO="${1}"
+CONTAINER_NAME="${2}"
+
+cat <<EOF
+version: "3"
+services:
+  hello-bench:
+    build:
+      context: "${REPO}/script/benchmark/hello-bench"
+      dockerfile: Dockerfile
+    container_name: ${CONTAINER_NAME}
+    privileged: true
+    working_dir: /go/src/github.com/ktock/stargz-snapshotter
+    command: tail -f /dev/null
+    environment:
+    - NO_PROXY=127.0.0.1,localhost
+    - HTTP_PROXY=${HTTP_PROXY:-}
+    - HTTPS_PROXY=${HTTPS_PROXY:-}
+    - http_proxy=${http_proxy:-}
+    - https_proxy=${https_proxy:-}
+    tmpfs:
+    - /tmp:exec,mode=777
+    volumes:
+    - "${REPO}:/go/src/github.com/ktock/stargz-snapshotter:ro"
+    - "/dev/fuse:/dev/fuse"
+    - "containerd-data:/var/lib/containerd:delegated"
+    - "containerd-stargz-grpc-data:/var/lib/containerd-stargz-grpc:delegated"
+    - "containerd-stargz-grpc-status:/run/containerd-stargz-grpc:delegated"
+volumes:
+  containerd-data:
+  containerd-stargz-grpc-data:
+  containerd-stargz-grpc-status:
+EOF

--- a/script/benchmark/hello-bench/Dockerfile
+++ b/script/benchmark/hello-bench/Dockerfile
@@ -1,0 +1,32 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM golang:1.12
+
+# basic tools
+RUN apt-get update -y && \
+    apt-get install -y libbtrfs-dev libseccomp-dev fuse python 
+
+# runtime dependencies
+RUN git clone https://github.com/opencontainers/runc \
+              $GOPATH/src/github.com/opencontainers/runc && \
+    cd $GOPATH/src/github.com/opencontainers/runc && \
+    git checkout d736ef14f0288d6993a1845745d6756cfc9ddd5a && \
+    GO111MODULE=off make -j2 BUILDTAGS='seccomp apparmor' && \
+    GO111MODULE=off make install && \
+    git clone https://github.com/containerd/containerd \
+              $GOPATH/src/github.com/containerd/containerd && \
+    cd $GOPATH/src/github.com/containerd/containerd && \
+    git checkout d5714702d1f78ad1149e78e204db0b53611ddb3c && \
+    GO111MODULE=off make -j2 && GO111MODULE=off make install

--- a/script/benchmark/hello-bench/config/config.containerd.toml
+++ b/script/benchmark/hello-bench/config/config.containerd.toml
@@ -1,0 +1,4 @@
+[proxy_plugins]
+  [proxy_plugins.stargz]
+    type = "snapshot"
+    address = "/run/containerd-stargz-grpc/containerd-stargz-grpc.sock"

--- a/script/benchmark/hello-bench/config/config.stargz.toml
+++ b/script/benchmark/hello-bench/config/config.stargz.toml
@@ -1,0 +1,1 @@
+noprefetch = true

--- a/script/benchmark/hello-bench/prepare.sh
+++ b/script/benchmark/hello-bench/prepare.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+MEASURING_SCRIPT=./script/benchmark/hello-bench/src/hello.py
+
+if [ $# -lt 1 ] ; then
+    echo "Specify benchmark target."
+    echo "Ex) ${0} <YOUR_ACCOUNT_NAME> --all"
+    echo "Ex) ${0} <YOUR_ACCOUNT_NAME> alpine busybox"
+    exit 1
+fi
+TARGET_REPOUSER="${1}"
+TARGET_IMAGES=${@:2}
+
+"${MEASURING_SCRIPT}" --user=${TARGET_REPOUSER} --op=prepare ${TARGET_IMAGES}

--- a/script/benchmark/hello-bench/reboot_containerd.sh
+++ b/script/benchmark/hello-bench/reboot_containerd.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+CONTAINERD_ROOT=/var/lib/containerd/
+CONTAINERD_CONFIG_DIR=/etc/containerd/
+REMOTE_SNAPSHOTTER_SOCKET=/run/containerd-stargz-grpc/containerd-stargz-grpc.sock
+REMOTE_SNAPSHOTTER_ROOT=/var/lib/containerd-stargz-grpc/
+REMOTE_SNAPSHOTTER_CONFIG_DIR=/etc/containerd-stargz-grpc/
+
+NOSNAPSHOTTER="${1:-}"
+
+RETRYNUM=30
+RETRYINTERVAL=1
+TIMEOUTSEC=180
+function retry {
+    SUCCESS=false
+    for i in $(seq ${RETRYNUM}) ; do
+        if eval "timeout ${TIMEOUTSEC} ${@}" ; then
+            SUCCESS=true
+            break
+        fi
+        echo "Fail(${i}). Retrying..."
+        sleep ${RETRYINTERVAL}
+    done
+    if [ "${SUCCESS}" == "true" ] ; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+function kill_all {
+    if [ "${1}" != "" ] ; then
+        ps aux | grep "${1}" | grep -v grep | grep -v $(basename ${0}) | sed -E 's/ +/ /g' | cut -f 2 -d ' ' | xargs -I{} kill -9 {} || true
+    fi
+}
+
+function cleanup {
+    rm -rf "${CONTAINERD_ROOT}"*
+    if [ -f "${REMOTE_SNAPSHOTTER_SOCKET}" ] ; then
+        rm "${REMOTE_SNAPSHOTTER_SOCKET}"
+    fi
+    if [ -d "${REMOTE_SNAPSHOTTER_ROOT}snapshotter/snapshots/" ] ; then 
+        find "${REMOTE_SNAPSHOTTER_ROOT}snapshotter/snapshots/" \
+             -maxdepth 1 -mindepth 1 -type d -exec umount "{}/fs" \;
+    fi
+    rm -rf "${REMOTE_SNAPSHOTTER_ROOT}"*
+}
+
+echo "cleaning up the environment..."
+kill_all "containerd"
+kill_all "containerd-stargz-grpc"
+cleanup
+if [ "${NOSNAPSHOTTER}" == "-nosnapshotter" ] ; then
+    echo "DO NOT RUN remote snapshotter"
+else
+    echo "running remote snaphsotter..."
+    containerd-stargz-grpc --log-level=debug \
+                           --address="${REMOTE_SNAPSHOTTER_SOCKET}" \
+                           --config="${REMOTE_SNAPSHOTTER_CONFIG_DIR}config.stargz.toml" &
+    retry ls "${REMOTE_SNAPSHOTTER_SOCKET}"
+fi
+echo "running containerd..."
+containerd --config="${CONTAINERD_CONFIG_DIR}config.containerd.toml" &
+retry ctr version

--- a/script/benchmark/hello-bench/run.sh
+++ b/script/benchmark/hello-bench/run.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+LEGACY_MODE="legacy"
+STARGZ_MODE="stargz"
+ESTARGZ_MODE="estargz"
+
+MEASURING_SCRIPT=./script/benchmark/hello-bench/src/hello.py
+REBOOT_CONTAINERD_SCRIPT=./script/benchmark/hello-bench/reboot_containerd.sh
+REPO_CONFIG_DIR=./script/benchmark/hello-bench/config/
+CONTAINERD_CONFIG_DIR=/etc/containerd/
+REMOTE_SNAPSHOTTER_CONFIG_DIR=/etc/containerd-stargz-grpc/
+
+if [ $# -lt 1 ] ; then
+    echo "Specify benchmark target."
+    echo "Ex) ${0} <YOUR_ACCOUNT_NAME> --all"
+    echo "Ex) ${0} <YOUR_ACCOUNT_NAME> alpine busybox"
+    exit 1
+fi
+TARGET_REPOUSER="${1}"
+TARGET_IMAGES=${@:2}
+
+function output {
+    echo "BENCHMARK_OUTPUT: ${1}"
+}
+
+function set_noprefetch {
+    NOPREFETCH="${1}"
+    sed -i 's/noprefetch = .*/noprefetch = '"${NOPREFETCH}"'/g' "${REMOTE_SNAPSHOTTER_CONFIG_DIR}config.stargz.toml"
+}
+
+NUM_OF_SUMPLES=1
+function measure {
+    NAME="${1}"
+    OPTION="${2}"
+    USER="${3}"
+    output "\"${NAME}\": ["
+    "${MEASURING_SCRIPT}" ${OPTION} --user=${USER} --op=run --experiments=${NUM_OF_SUMPLES} ${@:4}
+    output "],"
+}
+
+echo "Installing remote snapshotter..."
+mkdir -p /tmp/out
+GO111MODULE=off PREFIX=/tmp/out/ make clean && \
+    GO111MODULE=off PREFIX=/tmp/out/ make -j2 && \
+    GO111MODULE=off PREFIX=/tmp/out/ make install
+mkdir -p "${CONTAINERD_CONFIG_DIR}" && \
+    cp "${REPO_CONFIG_DIR}"config.containerd.toml "${CONTAINERD_CONFIG_DIR}"
+mkdir -p "${REMOTE_SNAPSHOTTER_CONFIG_DIR}" && \
+    cp "${REPO_CONFIG_DIR}"config.stargz.toml "${REMOTE_SNAPSHOTTER_CONFIG_DIR}"
+
+echo "========="
+echo "SPEC LIST"
+echo "========="
+uname -r
+cat /etc/os-release
+cat /proc/cpuinfo
+cat /proc/meminfo
+mount
+df
+
+echo "========="
+echo "BENCHMARK"
+echo "========="
+output "[{"
+
+"${REBOOT_CONTAINERD_SCRIPT}" -nosnapshotter
+measure "${LEGACY_MODE}" "--mode=legacy" ${TARGET_REPOUSER} ${TARGET_IMAGES}
+
+set_noprefetch "true" # disable prefetch
+"${REBOOT_CONTAINERD_SCRIPT}"
+measure "${STARGZ_MODE}" "--mode=stargz" ${TARGET_REPOUSER} ${TARGET_IMAGES}
+
+set_noprefetch "false" # enable prefetch
+"${REBOOT_CONTAINERD_SCRIPT}"
+measure "${ESTARGZ_MODE}" "--mode=estargz" ${TARGET_REPOUSER} ${TARGET_IMAGES}
+
+output "}]"

--- a/script/benchmark/hello-bench/src/gcc/main.c
+++ b/script/benchmark/hello-bench/src/gcc/main.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+  printf("hello\n");
+}

--- a/script/benchmark/hello-bench/src/hello.py
+++ b/script/benchmark/hello-bench/src/hello.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# The MIT License (MIT)
+# 
+# Copyright (c) 2015 Tintri
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os, sys, subprocess, select, random, urllib2, time, json, tempfile, shutil
+
+TMP_DIR = tempfile.mkdtemp()
+LEGACY_MODE = "legacy"
+STARGZ_MODE = "stargz"
+ESTARGZ_MODE = "estargz"
+DEFAULT_OPTIMIZER = "ctr-remote image optimize"
+BENCHMARKOUT_MARK = "BENCHMARK_OUTPUT: "
+
+def exit(status):
+    # cleanup
+    shutil.rmtree(TMP_DIR)
+    sys.exit(status)
+
+def tmp_dir():
+    tmp_dir.nxt += 1
+    return os.path.join(TMP_DIR, str(tmp_dir.nxt))
+tmp_dir.nxt = 0
+
+def tmp_copy(src):
+    dst = tmp_dir()
+    shutil.copytree(src, dst)
+    return dst
+
+def genargs(arg):
+    if arg == None or arg == "":
+        return ""
+    else:
+        return '-args \'["%s"]\'' % arg.replace('"', '\\\"').replace('\'', '\'"\'"\'')
+
+class RunArgs:
+    def __init__(self, env={}, arg='', stdin='', stdin_sh='sh', waitline='', mount=[]):
+        self.env = env
+        self.arg = arg
+        self.stdin = stdin
+        self.stdin_sh = stdin_sh
+        self.waitline = waitline
+        self.mount = mount
+
+class Bench:
+    def __init__(self, name, category='other'):
+        self.name = name
+        self.repo = name # TODO: maybe we'll eventually have multiple benches per repo
+        self.category = category
+
+    def __str__(self):
+        return json.dumps(self.__dict__)
+
+class BenchRunner:
+    ECHO_HELLO = set([])
+
+    CMD_ARG_WAIT = {'rethinkdb:2.3.6': RunArgs(waitline='Server ready'),
+                    'glassfish:4.1-jdk8': RunArgs(waitline='Running GlassFish'),
+    }
+
+    CMD_STDIN = {'gcc:9.2.0': RunArgs(stdin='cd /src; gcc main.c; ./a.out; exit\n',
+                                mount=[('gcc', '/src')]),
+    }
+
+    CMD_ARG = {'python:3.7': RunArgs(arg='python -c \'print("hello")\''),
+    }
+
+    # complete listing
+    ALL = dict([(b.name, b) for b in
+                [Bench('rethinkdb:2.3.6', 'database'),
+                 Bench('python:3.7', 'language'),
+                 Bench('gcc:9.2.0', 'language'),
+                 Bench('glassfish:4.1-jdk8', 'web-server'),
+             ]])
+
+    def __init__(self, user='library', mode=LEGACY_MODE, optimizer=DEFAULT_OPTIMIZER):
+        self.docker = 'ctr'
+        self.user = user
+        self.registry = 'docker.io/%s/' % user
+        self.mode = mode
+        self.optimizer = optimizer
+
+    def lazypull(self):
+        if self.mode == STARGZ_MODE or self.mode == ESTARGZ_MODE:
+            return True
+        else:
+            return False
+
+    def cleanup(self, name, image):
+        print "Cleaning up environment..."
+        cmd = '%s t kill -s 9 %s' % (self.docker, name)
+        print cmd
+        rc = os.system(cmd) # sometimes containers already exit. we ignore the failure.
+        cmd = '%s c rm %s' % (self.docker, name)
+        print cmd
+        rc = os.system(cmd)
+        assert(rc == 0)
+        cmd = '%s image rm %s' % (self.docker, image)
+        print cmd
+        rc = os.system(cmd)
+        assert(rc == 0)
+        cmd = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../reboot_containerd.sh') # clear cache
+        if not self.lazypull():
+            cmd += ' -nosnapshotter'
+        print cmd
+        rc = os.system(cmd)
+        assert(rc == 0)
+
+    def snapshotter_opt(self):
+        if self.lazypull():
+            return "--snapshotter=stargz"
+        else:
+            return ""
+
+    def add_suffix(self, repo):
+        if self.mode == ESTARGZ_MODE:
+            return "%s-esgz" % repo
+        elif self.mode == STARGZ_MODE:
+            return "%s-sgz" % repo
+        else:
+            return "%s-org" % repo
+
+    def pull_subcmd(self):
+        if self.lazypull():
+            return "rpull"
+        else:
+            return "pull"
+        
+    def docker_pullbin(self):
+        if self.lazypull():
+            return "ctr-remote"
+        else:
+            return "ctr"
+
+    def run_task(self, cid):
+        cmd = '%s t start %s' % (self.docker, cid)
+        print cmd
+        startrun = time.time()
+        rc = os.system(cmd)
+        runtime = time.time() - startrun
+        assert(rc == 0)
+        return runtime
+        
+    def run_echo_hello(self, repo, cid):
+        cmd = ('%s c create %s -- %s%s %s echo hello' %
+               (self.docker, self.snapshotter_opt(), self.registry, self.add_suffix(repo), cid))
+        print cmd
+        startcreate = time.time()
+        rc = os.system(cmd)
+        createtime = time.time() - startcreate
+        assert(rc == 0)
+        return createtime, self.run_task(cid)
+
+    def run_cmd_arg(self, repo, cid, runargs):
+        assert(len(runargs.mount) == 0)
+        cmd = '%s c create %s ' % (self.docker, self.snapshotter_opt())
+        cmd += '-- %s%s %s ' % (self.registry, self.add_suffix(repo), cid)
+        cmd += runargs.arg
+        print cmd
+        startcreate = time.time()
+        rc = os.system(cmd)
+        createtime = time.time() - startcreate
+        assert(rc == 0)
+        return createtime, self.run_task(cid)
+
+    def run_cmd_arg_wait(self, repo, cid, runargs):
+        env = ' '.join(['--env %s=%s' % (k,v) for k,v in runargs.env.iteritems()])
+        cmd = ('%s c create %s %s -- %s%s %s %s' %
+               (self.docker, self.snapshotter_opt(), env, self.registry, self.add_suffix(repo), cid, runargs.arg))
+        print cmd
+        startcreate = time.time()
+        rc = os.system(cmd)
+        createtime = time.time() - startcreate
+        assert(rc == 0)
+        cmd = '%s t start %s' % (self.docker, cid)
+        print cmd
+        runtime = 0
+        startrun = time.time()
+
+        # line buffer output
+        p = subprocess.Popen(cmd, shell=True, bufsize=1,
+                             stderr=subprocess.STDOUT,
+                             stdout=subprocess.PIPE)
+        while True:
+            l = p.stdout.readline()
+            if l == '':
+                continue
+            print 'out: ' + l.strip()
+            # are we done?
+            if l.find(runargs.waitline) >= 0:
+                runtime = time.time() - startrun
+                # cleanup
+                print 'DONE'
+                cmd = '%s t kill -s 9 %s' % (self.docker, cid)
+                rc = os.system(cmd)
+                assert(rc == 0)
+                break
+        p.wait()
+        return createtime, runtime
+
+    def run_cmd_stdin(self, repo, cid, runargs):
+        cmd = '%s c create %s ' % (self.docker, self.snapshotter_opt())
+        for a,b in runargs.mount:
+            a = os.path.join(os.path.dirname(os.path.abspath(__file__)), a)
+            a = tmp_copy(a)
+            cmd += '--mount type=bind,src=%s,dst=%s,options=rbind ' % (a,b)
+        cmd += '-- %s%s %s ' % (self.registry, self.add_suffix(repo), cid)
+        if runargs.stdin_sh:
+            cmd += runargs.stdin_sh # e.g., sh -c
+
+        print cmd
+        startcreate = time.time()
+        rc = os.system(cmd)
+        createtime = time.time() - startcreate
+        assert(rc == 0)
+        cmd = '%s t start %s' % (self.docker, cid)
+        print cmd
+        startrun = time.time()
+
+        p = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        print runargs.stdin
+        out, _ = p.communicate(runargs.stdin)
+        runtime = time.time() - startrun
+        print out
+        assert(p.returncode == 0)
+        return createtime, runtime
+
+    def run(self, bench, cid):
+        name = bench.name
+        print "Pulling the image..."
+        startpull = time.time()
+        cmd = ('%s images %s %s%s' %
+               (self.docker_pullbin(), self.pull_subcmd(), self.registry, self.add_suffix(name)))
+        print cmd
+        rc = os.system(cmd)
+        assert(rc == 0)
+        print "syncing..."
+        rc = os.system("sync")
+        assert(rc == 0)
+        pulltime = time.time() - startpull
+
+        runtime = 0
+        createtime = 0
+        if name in BenchRunner.ECHO_HELLO:
+            createtime, runtime = self.run_echo_hello(repo=name, cid=cid)
+        elif name in BenchRunner.CMD_ARG:
+            createtime, runtime = self.run_cmd_arg(repo=name, cid=cid, runargs=BenchRunner.CMD_ARG[name])
+        elif name in BenchRunner.CMD_ARG_WAIT:
+            createtime, runtime = self.run_cmd_arg_wait(repo=name, cid=cid, runargs=BenchRunner.CMD_ARG_WAIT[name])
+        elif name in BenchRunner.CMD_STDIN:
+            createtime, runtime = self.run_cmd_stdin(repo=name, cid=cid, runargs=BenchRunner.CMD_STDIN[name])
+        else:
+            print 'Unknown bench: '+name
+            exit(1)
+
+        return pulltime, createtime, runtime
+
+    def convert_echo_hello(self, repo):
+        self.mode = ESTARGZ_MODE
+        period=10
+        cmd = ('%s -period %s -entrypoint \'["/bin/sh", "-c"]\' -args \'["echo hello"]\' %s%s %s%s' %
+               (self.optimizer, period, repo, self.user, self.add_suffix(repo)))
+        print cmd
+        rc = os.system(cmd)
+        assert(rc == 0)
+
+    def convert_cmd_arg(self, repo, runargs):
+        self.mode = ESTARGZ_MODE
+        period = 30
+        assert(len(runargs.mount) == 0)
+        entry = ""
+        if runargs.arg != "": # FIXME: this is naive...
+            entry = '-entrypoint \'["/bin/sh", "-c"]\''
+        cmd = ('%s -period %s %s %s %s%s %s%s' %
+               (self.optimizer, period, entry, genargs(runargs.arg), repo, self.user, self.add_suffix(repo)))
+        print cmd
+        rc = os.system(cmd)
+        assert(rc == 0)
+
+    def convert_cmd_arg_wait(self, repo, runargs):
+        self.mode = ESTARGZ_MODE
+        period = 90
+        env = ' '.join(['-env %s=%s' % (k,v) for k,v in runargs.env.iteritems()])
+        cmd = ('%s -period %s %s %s %s%s %s%s' %
+               (self.optimizer, period, env, genargs(runargs.arg), repo, self.user, self.add_suffix(repo)))
+        print cmd
+        rc = os.system(cmd)
+        assert(rc == 0)
+
+    def convert_cmd_stdin(self, repo, runargs):
+        self.mode = ESTARGZ_MODE
+        period = 60
+        cmd = ('%s -period %s -entrypoint \'["/bin/sh", "-c"]\' %s %s%s %s%s' %
+               (self.optimizer, period, genargs(runargs.stdin_sh), repo, self.user, self.add_suffix(repo)))
+        print cmd
+        p = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        print runargs.stdin
+        out,_ = p.communicate(runargs.stdin)
+        print out
+        p.wait()
+        assert(p.returncode == 0)
+
+    def copy_img(self, repo):
+        self.mode = LEGACY_MODE
+        cmd = 'gcrane cp %s %s%s' % (repo, self.user, self.add_suffix(repo))
+        print cmd
+        rc = os.system(cmd)
+        assert(rc == 0)
+        self.mode = STARGZ_MODE
+        cmd = '%s --stargz-only %s %s%s' % (self.optimizer, repo, self.user, self.add_suffix(repo))
+        print cmd
+        rc = os.system(cmd)
+        assert(rc == 0)
+    
+    def prepare(self, bench):
+        name = bench.name
+        if name in BenchRunner.ECHO_HELLO:
+            self.convert_echo_hello(repo=name)
+        elif name in BenchRunner.CMD_ARG:
+            self.convert_cmd_arg(repo=name, runargs=BenchRunner.CMD_ARG[name])
+        elif name in BenchRunner.CMD_ARG_WAIT:
+            self.convert_cmd_arg_wait(repo=name, runargs=BenchRunner.CMD_ARG_WAIT[name])
+        elif name in BenchRunner.CMD_STDIN:
+            self.convert_cmd_stdin(repo=name, runargs=BenchRunner.CMD_STDIN[name])
+        else:
+            print 'Unknown bench: '+name
+            exit(1)
+        self.copy_img(name)
+
+    def operation(self, op, bench, cid):
+        if op == 'run':
+            return self.run(bench, cid)
+        elif op == 'prepare':
+            self.prepare(bench)
+            return 0, 0, 0
+        else:
+            print 'Unknown operation: '+op
+            exit(1)
+
+def main():
+    if len(sys.argv) == 1:
+        print 'Usage: bench.py [OPTIONS] [BENCHMARKS]'
+        print 'OPTIONS:'
+        print '--user=<user>'
+        print '--all'
+        print '--list'
+        print '--list-json'
+        print '--experiments'
+        print '--op=(prepare|run)'
+        print '--mode=(%s|%s|%s)' % (LEGACY_MODE, STARGZ_MODE, ESTARGZ_MODE)
+        exit(1)
+
+    benches = []
+    kvargs = {}
+    # parse args
+    for arg in sys.argv[1:]:
+        if arg.startswith('--'):
+            parts = arg[2:].split('=')
+            if len(parts) == 2:
+                kvargs[parts[0]] = parts[1]
+            elif parts[0] == 'all':
+                benches.extend(BenchRunner.ALL.values())
+            elif parts[0] == 'list':
+                template = '%-16s\t%-20s'
+                print template % ('CATEGORY', 'NAME')
+                for b in sorted(BenchRunner.ALL.values(), key=lambda b:(b.category, b.name)):
+                    print template % (b.category, b.name)
+            elif parts[0] == 'list-json':
+                print json.dumps([b.__dict__ for b in BenchRunner.ALL.values()])
+        else:
+            benches.append(BenchRunner.ALL[arg])
+
+    op = kvargs.pop('op', 'run')
+    trytimes = int(kvargs.pop('experiments', '1'))
+    if not op == "run":
+        trytimes = 1
+
+    # run benchmarks
+    runner = BenchRunner(**kvargs)
+    for bench in benches:
+        cid = '%s_bench_%d' % (bench.repo.replace(':', '-').replace('/', '-'), random.randint(1,1000000))
+
+        elapsed_times = []
+        pull_times = []
+        create_times = []
+        run_times = []
+
+        for i in range(trytimes):
+            start = time.time()
+            pulltime, createtime, runtime = runner.operation(op, bench, cid)
+            elapsed = time.time() - start
+            if op == "run":
+                runner.cleanup(cid, '%s%s' % (runner.registry, bench.repo))
+            elapsed_times.append(elapsed)
+            pull_times.append(pulltime)
+            create_times.append(createtime)
+            run_times.append(runtime)
+            print 'ITERATION %s:' % i
+            print 'elapsed %s' % elapsed
+            print 'pull    %s' % pulltime
+            print 'create  %s' % createtime
+            print 'run     %s' % runtime
+
+        row = {'mode':'%s' % runner.mode, 'repo':bench.repo, 'bench':bench.name, 'elapsed':sum(elapsed_times) / len(elapsed_times), 'elapsed_pull':sum(pull_times) / len(pull_times), 'elapsed_create':sum(create_times) / len(create_times), 'elapsed_run':sum(run_times) / len(run_times)}
+        js = json.dumps(row)
+        print '%s%s,' % (BENCHMARKOUT_MARK, js)
+        sys.stdout.flush()
+
+if __name__ == '__main__':
+    main()
+    exit(0)

--- a/script/benchmark/tools/format.sh
+++ b/script/benchmark/tools/format.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+OUTPUT_MARK="BENCHMARK_OUTPUT: "
+
+grep "${OUTPUT_MARK}" | sed -e 's/^'"${OUTPUT_MARK}"'//g' | sed -e ':begin;$!N;s/,\n\(\(}\|]\),*\)/\n\1/g;tbegin;P;D'

--- a/script/benchmark/tools/plot.sh
+++ b/script/benchmark/tools/plot.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+JSON="$(mktemp)"
+cat > "${JSON}"
+
+if [ "${1}" == "" ] ; then
+    echo "Specify directory for output"
+    exit 1
+fi
+
+DATADIR="${1}/"
+echo "output into: ${DATADIR}"
+
+MODES=( ${TARGET_MODES:-} )
+if [ ${#MODES[@]} -eq 0 ] ; then
+    MODES=("legacy" "stargz" "estargz")
+fi
+
+IMAGES=( ${TARGET_IMAGES:-} )
+if [ ${#IMAGES[@]} -eq 0 ] ; then
+    IMAGES=( $(cat "${JSON}" | jq -r '.[0]."'${MODES[0]}'" | .[].repo') )
+fi
+
+PLTFILE_ALL="${DATADIR}result.plt"
+GRAPHFILE_ALL="${DATADIR}result.png"
+
+cat <<EOF > "${PLTFILE_ALL}"
+set output '${GRAPHFILE_ALL}'
+set title "pull + startup time"
+set terminal png size 1000, 750
+set style data histogram
+set style histogram rowstack gap 1
+set style fill solid 1.0 border -1
+set key autotitle columnheader
+set xtics rotate by -45
+set lmargin 5
+set rmargin 5
+set tmargin 5
+set bmargin 5
+plot \\
+EOF
+
+NOTITLE=
+INDEX=1
+for IMGNAME in "${IMAGES[@]}" ; do
+    echo "[${INDEX}]Processing: ${IMGNAME}"
+    IMAGE=$(echo "${IMGNAME}" | sed 's|[/:]|-|g')
+    DATAFILE="${DATADIR}${IMAGE}.dat"
+    SUFFIX=', \'
+    if [ ${INDEX} -eq ${#IMAGES[@]} ] ; then
+        SUFFIX=''
+    fi
+    
+    echo "mode pull create run" > "${DATAFILE}"
+    for MODE in "${MODES[@]}"; do
+        PULLTIME=$(cat "${JSON}" | jq -r '.[0]."'"${MODE}"'"[] | select(.repo=="'"${IMGNAME}"'").elapsed_pull')
+        CREATETIME=$(cat "${JSON}" | jq -r '.[0]."'"${MODE}"'"[] | select(.repo=="'"${IMGNAME}"'").elapsed_create')
+        RUNTIME=$(cat "${JSON}" | jq -r '.[0]."'"${MODE}"'"[] | select(.repo=="'"${IMGNAME}"'").elapsed_run')
+        echo "${MODE} ${PULLTIME} ${CREATETIME} ${RUNTIME}" >> "${DATAFILE}"
+    done
+
+    echo 'newhistogram "'"${IMAGE}"'", "'"${DATAFILE}"'" u 2:xtic(1) fs pattern 1 lt -1 '"${NOTITLE}"', "" u 3 fs pattern 2 lt -1 '"${NOTITLE}"', "" u 4 fs pattern 3 lt -1 '"${NOTITLE}""${SUFFIX}" \
+         >> "${PLTFILE_ALL}"
+    NOTITLE=notitle
+    ((INDEX+=1))
+done
+
+gnuplot "${PLTFILE_ALL}"

--- a/script/benchmark/tools/table.sh
+++ b/script/benchmark/tools/table.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -euo pipefail
+
+JSON="$(mktemp)"
+cat > "${JSON}"
+
+MODES=( ${TARGET_MODES:-} )
+if [ ${#MODES[@]} -eq 0 ] ; then
+    MODES=("legacy" "stargz" "estargz")
+fi
+
+IMAGES=( ${TARGET_IMAGES:-} )
+if [ ${#IMAGES[@]} -eq 0 ] ; then
+    IMAGES=( $(cat "${JSON}" | jq -r '.[0]."'${MODES[0]}'" | .[].repo') )
+fi
+
+cat <<EOF
+# Benchmarking Result
+
+Runs on the ubuntu-18.04 runner on Github Actions.
+EOF
+
+for IMGNAME in "${IMAGES[@]}" ; do
+    cat <<EOF
+
+## ${IMGNAME}
+
+|mode|pull(sec)|create(sec)|run(sec)|
+---|---|---|---
+EOF
+    
+    for MODE in "${MODES[@]}"; do
+        PULLTIME=$(cat "${JSON}" | jq -r '.[0]."'"${MODE}"'"[] | select(.repo=="'"${IMGNAME}"'").elapsed_pull')
+        CREATETIME=$(cat "${JSON}" | jq -r '.[0]."'"${MODE}"'"[] | select(.repo=="'"${IMGNAME}"'").elapsed_create')
+        RUNTIME=$(cat "${JSON}" | jq -r '.[0]."'"${MODE}"'"[] | select(.repo=="'"${IMGNAME}"'").elapsed_run')
+        echo "|${MODE}|${PULLTIME}|${CREATETIME}|${RUNTIME}|"
+    done
+done


### PR DESCRIPTION
This commit enables us to measure container's startup performance with benchmark based on [HelloBench](https://github.com/Tintri/hello-bench) project.
On each opening and updating PR, we run the benchmark on the GithubAction's "ubuntu-18.04" runner and post the result as a comment. We use Docker Hub for storing legacy/stargz/extended-stargz images.

We should show the benchmarking result graphically but we don't have straightforward ways to post images as comments. Currently, we show the result as tables.