### PR TITLE
Hide state dir from ReadDir req to avoid affecting diffing result

### DIFF
--- a/stargz/fs.go
+++ b/stargz/fs.go
@@ -524,15 +524,6 @@ func (n *node) OpenDir(context *fuse.Context) ([]fuse.DirEntry, fuse.Status) {
 		}
 	}
 
-	// Append state directory in "/".
-	if n.e.Name == "" {
-		ents = append(ents, fuse.DirEntry{
-			Mode: syscall.S_IFDIR | n.s.mode(),
-			Name: stateDirName,
-			Ino:  n.s.ino(),
-		})
-	}
-
 	sort.Slice(ents, func(i, j int) bool { return ents[i].Name < ents[j].Name })
 	return ents, fuse.OK
 }


### PR DESCRIPTION
Fixes #31

This commit hides state dir(`/.stargz-snapshotter`) from getdents(2) to avoid affecting differ implementations.

```
# ctr-remote run --rm -t --snapshotter=stargz registry2:5000/ubuntu:18.04 test /bin/bash
root@32d4520a7fb5:/# ls -a /
.  ..  bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
root@32d4520a7fb5:/# ls -a /.stargz-snapshotter
.
..
sha256:e43418d927530df8736bfc362d26997f0c96bfcf90b6fb594510d54da0d3f366.json
sha256:e5a5544b4500edc7341910013633704a3edac54ee52990ac628a5fbc5a591075.json
sha256:f05c0f4ff792f589752764487e35ce1b60eaad399353b2fce046874b1b74df3b.json
sha256:feb2e5ef2735310a4116fbe6571cbcda2640f94ed5e2305e56d1b3b1c7995f6a.json
```

In the future, we should also make the state directory read-only(or prohibit to create files in) on the container's **merged** rootfs as well. This is because once we create a file in the state directory, overlayfs will create a directory which has the same name as the state directory in the upper layer directory and the state directory will be visible with getdents.

This PR includes only hiding the state dir and read-only state dir is out-of-scope for now.
