### PR TITLE
Clone RoundTripper for prefetch and background-fetch

### DIFF
--- a/script/benchmark/hello-bench/Dockerfile
+++ b/script/benchmark/hello-bench/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM golang:1.12
+FROM golang:1.14
 
 # basic tools
 RUN apt-get update -y && \

--- a/script/demo/Dockerfile
+++ b/script/demo/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM golang:1.12
+FROM golang:1.14
 
 # basic packages
 # docker-ce-cli is used only for users to log into registries (e.g. DockerHub)

--- a/script/integration/containerd-stargz-grpc/Dockerfile
+++ b/script/integration/containerd-stargz-grpc/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM golang:1.12
+FROM golang:1.14
 
 # Install FUSE for filesystems and Docker client for logging into the registry
 RUN apt-get update -y && \

--- a/script/integration/containerd/Dockerfile
+++ b/script/integration/containerd/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM golang:1.12
+FROM golang:1.14
 
 # basic tools
 # docker-ce-cli is used only to log into registry with ~/.docker/config.json

--- a/script/make.sh
+++ b/script/make.sh
@@ -143,7 +143,7 @@ fi
 if [ "$TARGETS" != "" ] ; then
     MINI_CONTEXT=$(mktemp -d)
     cat <<EOF > "${MINI_CONTEXT}/Dockerfile"
-FROM golang:1.12
+FROM golang:1.14
 RUN apt-get update -y && apt-get install -y fuse
 EOF
     IMAGE_NAME="minienv:$(sha256sum ${MINI_CONTEXT}/Dockerfile | cut -f 1 -d ' ')"

--- a/script/optimize/optimize/Dockerfile
+++ b/script/optimize/optimize/Dockerfile
@@ -12,7 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-FROM golang:1.12
+FROM golang:1.14
 
 # basic tools
 # docker-ce-cli is used only to log into registry with ~/.docker/config.json

--- a/stargz/reader/reader_test.go
+++ b/stargz/reader/reader_test.go
@@ -89,7 +89,7 @@ func TestPrefetch(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to make stargz reader: %v", err)
 			}
-			if err := gr.Prefetch(); err != nil {
+			if err := gr.PrefetchWithReader(sr); err != nil {
 				t.Errorf("failed to prefetch: %v", err)
 				return
 			}
@@ -191,13 +191,13 @@ func TestFailReader(t *testing.T) {
 
 	// tests for prefetch
 	br.success = true
-	if err = gr.Prefetch(); err != nil {
+	if err = gr.PrefetchWithReader(bsr); err != nil {
 		t.Errorf("failed to prefetch but wanted to succeed: %v", err)
 		return
 	}
 
 	br.success = false
-	if err = gr.Prefetch(); err == nil {
+	if err = gr.PrefetchWithReader(bsr); err == nil {
 		t.Errorf("succeeded to prefetch but wanted to fail")
 		return
 	}


### PR DESCRIPTION
We can use `Clone` method for `Transport` since [golang:1.14](https://github.com/golang/go/commit/5e404b362098318b5237673ef24834ef88912caa). This allows us to safely have a separated `RoundTripper` for prefetching, which can be expected to lead to performance improvement.