### PR TITLE
Fix error of resolving localhost in glassfish benchmarking image

### DIFF
--- a/script/benchmark/hello-bench/src/hello.py
+++ b/script/benchmark/hello-bench/src/hello.py
@@ -175,7 +175,7 @@ class BenchRunner:
         return runtime
         
     def run_echo_hello(self, repo, cid):
-        cmd = ('%s c create %s -- %s%s %s echo hello' %
+        cmd = ('%s c create --net-host %s -- %s%s %s echo hello' %
                (self.docker, self.snapshotter_opt(), self.registry, self.add_suffix(repo), cid))
         print cmd
         startcreate = time.time()
@@ -186,7 +186,7 @@ class BenchRunner:
 
     def run_cmd_arg(self, repo, cid, runargs):
         assert(len(runargs.mount) == 0)
-        cmd = '%s c create %s ' % (self.docker, self.snapshotter_opt())
+        cmd = '%s c create --net-host %s ' % (self.docker, self.snapshotter_opt())
         cmd += '-- %s%s %s ' % (self.registry, self.add_suffix(repo), cid)
         cmd += runargs.arg
         print cmd
@@ -198,7 +198,7 @@ class BenchRunner:
 
     def run_cmd_arg_wait(self, repo, cid, runargs):
         env = ' '.join(['--env %s=%s' % (k,v) for k,v in runargs.env.iteritems()])
-        cmd = ('%s c create %s %s -- %s%s %s %s' %
+        cmd = ('%s c create --net-host %s %s -- %s%s %s %s' %
                (self.docker, self.snapshotter_opt(), env, self.registry, self.add_suffix(repo), cid, runargs.arg))
         print cmd
         startcreate = time.time()
@@ -232,7 +232,7 @@ class BenchRunner:
         return createtime, runtime
 
     def run_cmd_stdin(self, repo, cid, runargs):
-        cmd = '%s c create %s ' % (self.docker, self.snapshotter_opt())
+        cmd = '%s c create --net-host %s ' % (self.docker, self.snapshotter_opt())
         for a,b in runargs.mount:
             a = os.path.join(os.path.dirname(os.path.abspath(__file__)), a)
             a = tmp_copy(a)


### PR DESCRIPTION
We are getting an error on resolving localhost address during benchmarking `glassfish:4.1-jdk8` for all type of images (all of `org`, `sgz` and `esgz`).

```
out: SEVERE: Cannot determine host name, will use localhost exclusively
out: java.net.UnknownHostException: e299678ae708: e299678ae708: unknown error
out: at java.net.InetAddress.getLocalHost(InetAddress.java:1505)
...
```

This commit fixes it by allowing benchmarking images using the host's well-configured network namespace.